### PR TITLE
Remove npm audit issues & add Call SID to intial GET

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,26 +3,26 @@
   "version": "0.1.0",
   "author": "Steve Sokol",
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-contrib-jshint": "~0.6.3",
-    "grunt-contrib-watch": "~0.5.3",
+    "grunt": "^1.0.3",
     "grunt-contrib-compass": "~0.6.0",
     "grunt-contrib-concat": "~0.5.1",
-    "util": "~0.10.3",
-    "grunt-execute": "~0.2.2"
+    "grunt-contrib-jshint": "^1.1.0",
+    "grunt-contrib-watch": "^1.1.0",
+    "grunt-execute": "~0.2.2",
+    "util": "~0.10.3"
   },
   "dependencies": {
-    "md5": "~2.0.0",
-    "redis": "~2.2.5",
-    "hiredis": "~0.4.1",
-    "flite": "~0.1.2",
-    "node-fetch": "~1.3.3",
-    "xmldoc": "~0.3.2",
-    "download": "~4.4.1",
-    "form-data": "~1.0.0-rc3",
+    "ari-client": "^1.1.1",
     "bluebird": "~2.10.2",
-    "ari-client": "~0.3.0",
+    "download": "^7.0.0",
+    "express": "^4.16.3",
+    "flite": "~0.1.2",
+    "form-data": "~1.0.0-rc3",
+    "hiredis": "~0.4.1",
+    "md5": "~2.0.0",
+    "node-fetch": "~1.3.3",
     "node-uuid": "~1.4.3",
-    "express": "~4.13.3"
+    "redis": "~2.2.5",
+    "xmldoc": "~0.3.2"
   }
 }

--- a/src/aria_call.js
+++ b/src/aria_call.js
@@ -47,8 +47,6 @@ var makeAction = function(xml, parent) {
 // make subsequent requests, optionally passing back data
 var fetchTwiml = function(method, twimlURL, call, data) {
 
-  console.log("Fetching Twiml From: " + twimlURL);
-  
   var options = {
     method: method || "POST",
     body: data || null
@@ -59,6 +57,8 @@ var fetchTwiml = function(method, twimlURL, call, data) {
     twimlURL = url.resolve(call.baseUrl, twimlURL);
   }
   
+  console.log("Fetching Twiml From:%s Options:%s", twimlURL, util.inspect(options));
+
   fetch(twimlURL, options)
     .then(function(res) {
       return res.text();
@@ -165,8 +165,9 @@ function AriaCall(client, channel, url, twiml, done) {
   });
 
   // fetch the Twiml for this call
+  //
+  url += "&CallSid=" + this.sid; 
   fetchTwiml("GET", url, that, null);
-
 }
 
 

--- a/src/twiml_play.js
+++ b/src/twiml_play.js
@@ -119,24 +119,18 @@ twimlActions.Play = function(command, callback) {
 
   // generate a hash which we will use as the filename
   var hashName = md5(fileURL.href);
-  var fileName = hashName + path.extname(fileURL.href);
+  var options = {
+    filename : hashName + path.extname(fileURL.href)
+  };
 
-  // create a downloader object and fetch the file
-  var dl = new download({
-    mode: "755"
+  // download file
+  download(fileURL.href, ariaConfig.audioPath, options).then(() => {
+    console.log("Retrieved %s -> %s%s", fileURL.href, ariaConfig.audioPath, options.filename);
+    play(hashName, exit);
+  }).catch((err) => {
+    console.log("Channel " + channel.id + " - ERROR: Unable to download requested file.");
+    console.error(err);
   });
-  dl.get(fileURL.href)
-    .dest(ariaConfig.audioPath)
-    .rename(fileName)
-    .run(function(err, files) {
-      if (err) {
-        console.log("Channel " + channel.id + " - ERROR: Unable to download requested file.");
-        console.error(err);
-        exit();
-      } else {
-        play(hashName, exit);
-      }
-    });
 };
 
 


### PR DESCRIPTION
- update NPM packages to remove warnings in 'npm audit'
- Audio file download (within Play) amended to match updated package
- pass the call SID on the query string with the initial GET

This last change is required by our twiML back-end which sets up session parameters when the initial request is made and needs the SID to tie subsequent requests together.